### PR TITLE
Fix Docker cointainer build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM base AS build
 
 # Install packages needed to build gems
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential git libvips pkg-config libpq-dev nodejs npm yarn
+    apt-get install --no-install-recommends -y build-essential git libvips pkg-config libpq-dev libyaml-dev nodejs npm yarn
 
 # Install application gems
 COPY Gemfile Gemfile.lock ./


### PR DESCRIPTION
libyaml-dev got removed in the base image in
https://github.com/docker-library/ruby/commit/7f078b1b01338e19130eb8b01cb7f35153ba6b04.

While this change did get reverted in
https://github.com/docker-library/ruby/commit/6f84caae95715928a3ed9c9753f844e03b3d5ff4 it will be removed in the next Ruby version, so we as well fix it now.