### PR TITLE
fix(renovate): optimize config for ruby

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -5,17 +5,23 @@
     ":semanticCommits",
     "group:allNonMajor",
     "group:allDigest",
+    "group:rubyOnRails",
     ":enableVulnerabilityAlertsWithLabel(security)",
   ],
   packageRules: [
     {
-      matchUpdateTypes: ["minor", "patch", "digest"],
-      automerge: true,
-    },
-    {
       matchUpdateTypes: ["digest"],
+      automerge: true,
       minimumReleaseAge: "1 day",
     },
+    {
+      // Ruby doesn't follow semver, so we separate minor versions from the all non-major group
+      matchDepNames: ["ruby", "registry.docker.com/library/ruby"],
+      matchUpdateTypes: ["minor"],
+      groupName: "Ruby",
+      groupSlug: "ruby",
+      automerge: false,
+    }
   ],
   platformAutomerge: true,
   prHourlyLimit: 0,


### PR DESCRIPTION
These changes should achieve the following:
- Separate rails related updates into a separate PR always
- Separate ruby minor update into a separate PR always
- Be more conservative and only automatically merge digest updates.